### PR TITLE
fix(rsync): Ignore exit code 24 "some files vanished"

### DIFF
--- a/couchcopy
+++ b/couchcopy
@@ -37,6 +37,20 @@ async def subprocess(*args, shell=False):
             stderr=asyncio.subprocess.PIPE)
     stdout, stderr = await p.communicate()
     stdout, stderr = stdout.decode(), stderr.decode()
+    if args[0] == 'rsync' and p.returncode == 24:
+        # When a file is deleted between the start of rsync and the moment
+        # the file is copied, rsync outputs a "warning: some files vanished"
+        # log and it exits with return code 24.
+        # See upstream explanation:
+        # https://bugzilla.samba.org/show_bug.cgi?id=10356
+        # Despite the non-zero return code, rsync does its work as if
+        # nothing happened.
+        # We think it's OK that CouchDB delete files thus we print the rsync
+        # warning but we ignore its return code.
+        # If more critical exit codes are returned, they are prioritized by
+        # rsync, so it's OK to ignore exit code 24.
+        print(stderr)
+        return stdout
     if p.returncode == 0:
         return stdout
     raise Exception(f'Command {args[0]} returned code {p.returncode}, stdout: '


### PR DESCRIPTION
As said in the code comment, exit code 24 is used by rsync when a file is
deleted in the middle of the rsync.
But that exit code is not a real exit code:

- rsync does its work like if there is no error
- if there is another, more important, error, rsync prioritize it and uses its
  exit code.

So, it's not satisfying but it's fine to ignore the rsync exit code 24.
[The upstream official answer] suggests exactly that.
[The upstream official answer] also remove the warning log. On my side I think
it's cool to keep it, for example for debugging.

To verify this commit I use `fallocate -l 1G z_big_DB` and
`fallocate -l 1k delete_me` commands to create fake files in a small CouchDB
instance and I checked that, during a backup, the rsync warning was logged, the
exit code ignored, and the `tar.gz` file created contains the expected CouchDB
shards files.

[The upstream official answer]: https://bugzilla.samba.org/show_bug.cgi?id=10356

---
Not in the commit message.
When the error is raised, the couchcopy output looks like this:
```
$ ./couchcopy backup localhost,/couchdb/data/dir toto.tar.gz
[rsync...]
file has vanished: "/tmp/couchcopy-8b5iag9h/data/shards/00000000-7fffffff/delete_me"
rsync warning: some files vanished before they could be transferred (code 24) at main.c(1330) [sender=3.2.3]

[tar...]
Done!
```
