### PR TITLE
backup: Fix rare tar error "File removed before we read it"

### DIFF
--- a/couchcopy
+++ b/couchcopy
@@ -108,7 +108,8 @@ async def backup(hostname, path, output, nodes_names=None):
             if returncode1 == 1:
                 stderr1 = '\n'.join(
                     l for l in stderr1.decode().splitlines()
-                    if not l.endswith('file changed as we read it')).encode()
+                    if not l.endswith('File removed before we read it',
+                                      'file changed as we read it')).encode()
                 if not stderr1:
                     returncode1 = 0
 


### PR DESCRIPTION
During the tar step of a backup, CouchDB can delete files while we're transferring them. This is known, and a workaround has been implemented and tested [^1] in my original implementation.

However, a similar error case can happen: `File removed before we read it`, instead of `file changed as we read it`. (Note that the two error strings don't have the same case, it seems normal, as found in the tar source code [^2] [^3].)

This commit handles this other case too, to prevent couchcopy from erroring. I couldn't test it because my test script [^1] doesn't produce such errors: they seem to be rare because it needs to happen at a very specific time. However, this problem happened to me this morning in production (for the first time), so I'm confident that it exists and the error message is accurate.

[^1]: https://github.com/tolteck/couchcopy/pull/5#discussion_r1235112047
[^2]: https://git.savannah.gnu.org/cgit/tar.git/tree/src/create.c?h=970f999#n1573
[^3]: https://git.savannah.gnu.org/cgit/tar.git/tree/src/create.c?h=970f999#n1659