### PR TITLE
backup: Fix new warning on tar output detection

### DIFF
--- a/couchcopy
+++ b/couchcopy
@@ -108,8 +108,8 @@ async def backup(hostname, path, output, nodes_names=None):
             if returncode1 == 1:
                 stderr1 = '\n'.join(
                     l for l in stderr1.decode().splitlines()
-                    if not l.endswith('File removed before we read it',
-                                      'file changed as we read it')).encode()
+                    if not l.endswith(('File removed before we read it',
+                                       'file changed as we read it'))).encode()
                 if not stderr1:
                     returncode1 = 0
 


### PR DESCRIPTION
This fixes a bug introduced by previous commit c1c4c02 “Fix rare tar error "File removed before we read it"”. Indeed, Python `endswith()` can accept a tuple of strings in the first argument, but not as the list of argument [^1].

Unfortunately, because of the lack of tests for commit c1c4c02, I detected it during a backup on a real server:

    [tar+ssh+gzip...]
    Traceback (most recent call last):
      …
      File "/usr/local/bin/couchcopy", line 111, in <genexpr>
        if not l.endswith('File removed before we read it',
    TypeError: slice indices must be integers or None or have an __index__ method

I made sure this is the correct syntax by testing:

```python
>>> s = '/dir/file: file changed as we read it'
>>> s.endswith('File removed before we read it', 'file changed as we read it')
TypeError: slice indices must be integers or None or have an __index__ method
>>> s.endswith(('File removed before we read it', 'file changed as we read it'))
True
```

[^1]: https://docs.python.org/3/library/stdtypes.html#str.endswith