### PR TITLE
restore: Fix crash when restoring on a 1-node

### DIFF
--- a/couchcopy
+++ b/couchcopy
@@ -211,7 +211,7 @@ async def change_nodes_names(user, password, url, names):
         shard_ranges = sorted(list(data['by_range'].keys()))
         q_from_archive = len(shard_ranges)
         _, data = await couch._server._get('/_node/_local/_config')
-        q_from_cluster = int(data['cluster']['q'])
+        q_from_cluster = int(data.get('cluster', {}).get('q', 2))
         assert q_from_cluster == q_from_archive, (
             f'Error q from CouchDB ({q_from_cluster}) != q from archive '
             f'({q_from_archive}), you need to change the `q` value used by '
@@ -357,7 +357,7 @@ async def restore(archive, cred, hostnames, paths, ports, names, couchdb_start,
             f'Error in names: {current_names} != {sorted(names)}. Try to '
             f'change nodes names with [nodename] arguments.')
         _, data = await couch._server._get('/_node/_local/_config')
-        assert int(data['cluster']['n']) >= len(names), (
+        assert int(data.get('cluster', {}).get('n', 1)) >= len(names), (
             'Error n < nodes count, this is not supported, for more infos see '
             'the README.')
 


### PR DESCRIPTION
When trying to use `couchcopy restore backup.tar.gz user:pass@localhost,/var/lib/couchdb` on a freshly-installed CouchDB on Rocky Linux 9, the following error occurs:

    Traceback (most recent call last):
      …
        assert int(data['cluster']['n']) >= len(names), (
    KeyError: 'cluster'

Then later:

    Traceback (most recent call last):
      …
        q_from_cluster = int(data['cluster']['q'])
    KeyError: 'cluster'

Indeed, `[cluster] n = …, q = …` are not set in configuration by default.

In such a case, let's take the default values for `n` and `q` (1 node, 2 shards [^1]).

[^1]: https://docs.couchdb.org/en/stable/config/cluster.html#cluster